### PR TITLE
The implementation of `eredis-filter` seems have some problems. 

### DIFF
--- a/eredis.el
+++ b/eredis.el
@@ -120,7 +120,6 @@ as it first constructs a list of key value pairs then uses that to construct the
     (cdr (assoc chr chr-type-alist))))
 
 (defun eredis-parse-response (response)
-  (message "%s" response)
   (let ((response-type (eredis-response-type-of response)))
     (cond ((eq response-type 'error)
            (eredis-parse-error-response response))


### PR DESCRIPTION
according to the elisp manual(http://www.gnu.org/software/emacs/manual/html_node/elisp/Filter-Functions.html#Filter-Functions). 

> the output to the filter may come in chunks of any size. A program that produces the same output twice in a row may send it as one batch of 200 characters one time, and five batches of 40 characters the next. If the filter looks for certain text strings in the subprocess output, make sure to handle the case where one of these strings is split across two or more batches of output; one way to do this is to insert the received text into a temporary buffer, which can then be searched. 

So, the implementation of `eredis-filter` seems have some problems. I'm trying to fix it

Bye the way,may I be the collaborator please?
